### PR TITLE
Moved AudioContext instantiation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2809,7 +2809,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3224,7 +3225,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3280,6 +3282,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3323,12 +3326,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/util/ring.js
+++ b/src/util/ring.js
@@ -1,17 +1,17 @@
-const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-
 const ring = {
     init() {
+        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
         this.oscillator = audioContext.createOscillator();
         this.gainNode = audioContext.createGain();
 
         this.oscillator.connect(this.gainNode);
         this.gainNode.connect(audioContext.destination);
         this.oscillator.type = 'triangle';
+        return audioContext;
     },
 
     play(freq, numPulses, pulseLen) {
-        this.init();
+        const audioContext = this.init();
         this.oscillator.frequency.value = freq;
 
         const imax = 2 * numPulses;


### PR DESCRIPTION
# Moved the AudioContext instantiation into the init function
Because, 
> If an AudioContext is created prior to the document receiving a user 
      gesture, it will be created in the "suspended" state, and you will 
      need to call resume() after a user gesture is received.
- From https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio